### PR TITLE
Update MainBlock.svelte

### DIFF
--- a/src/components/blocks/MainBlock.svelte
+++ b/src/components/blocks/MainBlock.svelte
@@ -12,7 +12,7 @@ import "github.com/gofiber/fiber"
 func main() {
   app := fiber.New()
 
-  app.get("/", func (c *fiber.Ctx) {
+  app.Get("/", func (c *fiber.Ctx) {
     c.Send("Hello, World!")
   })
 


### PR DESCRIPTION
`get` method of the first sample in the site index should be exported.