### PR TITLE
Rename Timeout to Expiration

### DIFF
--- a/components/blocks/RateLimiter.tsx
+++ b/components/blocks/RateLimiter.tsx
@@ -5,6 +5,7 @@ const exampleCode = `package main
 
 import (
     "log"
+    "time"
 
     "github.com/gofiber/fiber/v2"
     "github.com/gofiber/fiber/v2/middleware/limiter"
@@ -15,7 +16,7 @@ func main() {
 
   // 3 requests per 10 seconds max
   app.Use(limiter.New(limiter.Config{
-      Timeout:  10,
+      Expiration: 10 * time.Second,
       Max:      3,
   }))
 


### PR DESCRIPTION
"Timeout" is not exists in rate limiter config. It is replaced by "Expiration".