### PR TITLE
🩹 Fix: Re-align Rate Limiter code block

### DIFF
--- a/components/blocks/RateLimiter.tsx
+++ b/components/blocks/RateLimiter.tsx
@@ -17,7 +17,7 @@ func main() {
   // 3 requests per 10 seconds max
   app.Use(limiter.New(limiter.Config{
       Expiration: 10 * time.Second,
-      Max:      3,
+      Max:        3,
   }))
 
   // ...


### PR DESCRIPTION
On https://gofiber.io, the rate limiter section has a misaligned code block for `limiter.Config{}`:

<img width="543" alt="image" src="https://github.com/user-attachments/assets/fcc5d633-3510-4d8e-bf06-b13f9d7a0851">

This is fixed by updating [components/blocks/RateLimiter.tsx](https://github.com/gofiber/website/blob/master/components/blocks/RateLimiter.tsx#L20) to add 2 extra spaces after `Max:`.

Fixes: #110 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor formatting adjustment made to the `Max` field in the `RateLimiterBlock` component for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->