### PR TITLE
Improve dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,45 @@ updates:
       - "🤖 Dependencies"
     schedule:
       interval: "daily"
+    groups:
+      lint-tools:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@next/eslint-plugin-next"
+          - "@stylistic/eslint-plugin"
+          - "prettier"
+      types:
+        patterns:
+          - "typescript"
+          - "typescript-*"
+          - "@types/*"
+          - "@typescript-eslint*"
+      react-next:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+      fontawesome:
+        patterns:
+          - "@fortawesome/*"
+      sass:
+        patterns:
+          - "sass"
+          - "sass-loader"
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:
       - "🤖 Dependencies"
     schedule:
       interval: "daily"
+    groups:
+      actions:
+        patterns:
+          - "actions/*"
+      third-party-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"


### PR DESCRIPTION
## Summary
- expand dependabot configuration with multiple groups for npm dependencies
- group GitHub Actions updates

## Testing
- `yarn` *(fails: Bad response 403)*
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686e10458c44832692ac4498526f1a64